### PR TITLE
[nanoMIPS] Add eh_frame start and end symbols

### DIFF
--- a/gold/nanomips.cc
+++ b/gold/nanomips.cc
@@ -2141,6 +2141,11 @@ class Target_nanomips : public Sized_target<size, big_endian>
     sections.insert(".nanoMIPS.abiflags");
   }
 
+  // Defines eh_frame and eh_frame_hdr start and end symbols if these
+  // sections are defined.
+  void
+  do_define_standard_symbols(Symbol_table*, Layout*);
+
  private:
   // The class which scans relocations.
   class Scan
@@ -2341,6 +2346,12 @@ class Target_nanomips : public Sized_target<size, big_endian>
   // Calculate value of _gp symbol.
   void
   set_gp(Layout*, Symbol_table*);
+
+  // Define start and end symbols, used to define eh_frame start and
+  // end
+  void
+  define_start_end_symbols(const char* start, const char* end,
+        Symbol_table*, Output_section*);
 
   // Information about this specific target which we pass to the
   // general Target structure.
@@ -6641,6 +6652,69 @@ Target_nanomips<size, big_endian>::do_finalize_sections(
                                     : this->stubs_->rel_stubs());
   layout->add_target_dynamic_tags(true, this->got_, rel_stubs,
                                   this->rel_dyn_, true, false);
+}
+
+template <int size, bool big_endian>
+void
+Target_nanomips<size, big_endian>::do_define_standard_symbols(
+    Symbol_table* symtab,
+    Layout* layout)
+{
+  Output_section* eh_frame_section =
+        layout->find_output_section(".eh_frame");
+
+  if (eh_frame_section != NULL)
+    {
+      this->define_start_end_symbols("__eh_frame_start",
+            "__eh_frame_end",
+            symtab,
+            eh_frame_section);
+      Output_section* eh_frame_hdr_section =
+            layout->find_output_section(".eh_frame_hdr");
+
+      if (eh_frame_hdr_section != NULL)
+        this->define_start_end_symbols("__eh_frame_hdr_start",
+            "__eh_frame_hdr_end",
+            symtab,
+            eh_frame_hdr_section);
+    }
+}
+
+template <int size, bool big_endian>
+void
+Target_nanomips<size, big_endian>::define_start_end_symbols(
+      const char* start,
+      const char* end,
+      Symbol_table* symtab,
+      Output_section* out_sec)
+{
+  gold_assert(out_sec != NULL);
+
+  symtab->define_in_output_data(start,
+      NULL, // version
+      Symbol_table::PREDEFINED,
+      out_sec,
+      0, // value
+      0, // symsize
+      elfcpp::STT_NOTYPE,
+      elfcpp::STB_GLOBAL,
+      elfcpp::STV_HIDDEN,
+      0, // nonvis
+      false, // offset_is_from_end
+      true); // only_if_ref
+
+  symtab->define_in_output_data(end,
+      NULL, // version
+      Symbol_table::PREDEFINED,
+      out_sec,
+      0, // value
+      0, // symsize
+      elfcpp::STT_NOTYPE,
+      elfcpp::STB_GLOBAL,
+      elfcpp::STV_HIDDEN,
+      0, // nonvis
+      true, // offset_is_from_end
+      true); // only_if_ref
 }
 
 // Relocate section data.

--- a/gold/testsuite/Makefile.am
+++ b/gold/testsuite/Makefile.am
@@ -4927,6 +4927,38 @@ nanomips_fix_hw110880.o: nanomips_fix_hw110880.s
 
 MOSTLYCLEANFILES += nanomips_fix_hw110880
 
+# Test that the eh_frame start/end symbols are properly created
+check_SCRIPTS += nanomips_eh_frame_start_end_syms.sh
+check_DATA += nanomips_eh_frame_start_end_syms_1.stdout \
+              nanomips_eh_frame_start_end_syms_2.stdout
+
+nanomips_eh_frame_start_end_syms_2.stdout: nanomips_eh_frame_start_end_syms_2
+	$(TEST_READELF) -Ss $< > $@
+
+nanomips_eh_frame_start_end_syms_1.stdout: nanomips_eh_frame_start_end_syms_1
+	$(TEST_READELF) -Ss $< > $@
+
+nanomips_eh_frame_start_end_syms_2: nanomips_eh_frame_start_end_syms_2.o \
+                                    ../ld-new
+	../ld-new --section-start .eh_frame=0x1000 --section-start \
+	          .eh_frame_hdr=0x2000 --section-start .text=0x3000 \
+			  --eh-frame-hdr \
+			  nanomips_eh_frame_start_end_syms_2.o -o $@
+
+nanomips_eh_frame_start_end_syms_1: nanomips_eh_frame_start_end_syms_1.o \
+                                    ../ld-new
+	../ld-new --section-start .eh_frame=0x1000 --section-start .text=0x2000 \
+	          nanomips_eh_frame_start_end_syms_1.o -o $@
+
+nanomips_eh_frame_start_end_syms_2.o: nanomips_eh_frame_start_end_syms.s
+	$(TEST_AS) -EL -march=32r6 -m32 --defsym hdr=1 -o $@ $<
+
+nanomips_eh_frame_start_end_syms_1.o: nanomips_eh_frame_start_end_syms.s
+	$(TEST_AS) -EL -march=32r6 -m32 -o $@ $<
+
+MOSTLYCLEANFILES += nanomips_eh_frame_start_end_syms_1 \
+                    nanomips_eh_frame_start_end_syms_2
+
 endif DEFAULT_TARGET_NANOMIPS
 
 endif NATIVE_OR_CROSS_LINKER

--- a/gold/testsuite/Makefile.in
+++ b/gold/testsuite/Makefile.in
@@ -1114,6 +1114,8 @@ check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 # Not nanoMIPS specific, but we only run these tests on host.
 
 # Test that the -fix-nmips-hw110880 performs transformations
+
+# Test that the eh_frame start/end symbols are properly created
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@am__append_106 = nanomips_pcrel_out_of_range.sh \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_gprel_out_of_range.sh \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_sort_by_ref.sh \
@@ -1127,7 +1129,8 @@ check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_saverestore_relax.sh \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_bxxzc32_relax.sh \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_emit_relocs.sh \
-@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_fix_hw110880.sh
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_fix_hw110880.sh \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_eh_frame_start_end_syms.sh
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@am__append_107 = nanomips_b_out_of_range_pcrel.stdout \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_b_out_of_range_insn32_pcrel.stdout \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_b_out_of_range_nmf_pcrel.stdout \
@@ -1191,7 +1194,9 @@ check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_saverestore_relax.stdout \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_bxxzc32_relax.stdout \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_emit_relocs.stdout \
-@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_fix_hw110880.stdout
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_fix_hw110880.stdout \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_eh_frame_start_end_syms_1.stdout \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_eh_frame_start_end_syms_2.stdout
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@am__append_108 = nanomips_b_out_of_range_pcrel \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_b_out_of_range_insn32_pcrel \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_b_out_of_range_nmf_pcrel \
@@ -1249,7 +1254,9 @@ check_PROGRAMS = $(am__EXEEXT_1) $(am__EXEEXT_2) $(am__EXEEXT_3) \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_saverestore_relax \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_bxxzc32_relax \
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_emit_relocs \
-@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_fix_hw110880
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_fix_hw110880 \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_eh_frame_start_end_syms_1 \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	nanomips_eh_frame_start_end_syms_2
 @DEFAULT_TARGET_X86_64_TRUE@am__append_109 = *.dwo *.dwp
 @DEFAULT_TARGET_X86_64_TRUE@am__append_110 = dwp_test_1.sh \
 @DEFAULT_TARGET_X86_64_TRUE@	dwp_test_2.sh
@@ -5685,6 +5692,8 @@ nanomips_emit_relocs.sh.log: nanomips_emit_relocs.sh
 	@p='nanomips_emit_relocs.sh'; $(am__check_pre) $(LOG_COMPILE) "$$tst" $(am__check_post)
 nanomips_fix_hw110880.sh.log: nanomips_fix_hw110880.sh
 	@p='nanomips_fix_hw110880.sh'; $(am__check_pre) $(LOG_COMPILE) "$$tst" $(am__check_post)
+nanomips_eh_frame_start_end_syms.sh.log: nanomips_eh_frame_start_end_syms.sh
+	@p='nanomips_eh_frame_start_end_syms.sh'; $(am__check_pre) $(LOG_COMPILE) "$$tst" $(am__check_post)
 dwp_test_1.sh.log: dwp_test_1.sh
 	@p='dwp_test_1.sh'; $(am__check_pre) $(LOG_COMPILE) "$$tst" $(am__check_post)
 dwp_test_2.sh.log: dwp_test_2.sh
@@ -9084,6 +9093,30 @@ uninstall-am:
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	--section-start .bar=0x52012500 --section-start .frob=0x2000000 -o $@
 
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_fix_hw110880.o: nanomips_fix_hw110880.s
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	$(TEST_AS) -EL -march=32r6 -m32 -o $@ $<
+
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_eh_frame_start_end_syms_2.stdout: nanomips_eh_frame_start_end_syms_2
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	$(TEST_READELF) -Ss $< > $@
+
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_eh_frame_start_end_syms_1.stdout: nanomips_eh_frame_start_end_syms_1
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	$(TEST_READELF) -Ss $< > $@
+
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_eh_frame_start_end_syms_2: nanomips_eh_frame_start_end_syms_2.o \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@                                    ../ld-new
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	../ld-new --section-start .eh_frame=0x1000 --section-start \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	          .eh_frame_hdr=0x2000 --section-start .text=0x3000 \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@			  --eh-frame-hdr \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@			  nanomips_eh_frame_start_end_syms_2.o -o $@
+
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_eh_frame_start_end_syms_1: nanomips_eh_frame_start_end_syms_1.o \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@                                    ../ld-new
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	../ld-new --section-start .eh_frame=0x1000 --section-start .text=0x2000 \
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	          nanomips_eh_frame_start_end_syms_1.o -o $@
+
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_eh_frame_start_end_syms_2.o: nanomips_eh_frame_start_end_syms.s
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	$(TEST_AS) -EL -march=32r6 -m32 --defsym hdr=1 -o $@ $<
+
+@DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@nanomips_eh_frame_start_end_syms_1.o: nanomips_eh_frame_start_end_syms.s
 @DEFAULT_TARGET_NANOMIPS_TRUE@@NATIVE_OR_CROSS_LINKER_TRUE@	$(TEST_AS) -EL -march=32r6 -m32 -o $@ $<
 
 # Tests for the dwp tool.

--- a/gold/testsuite/nanomips_eh_frame_start_end_syms.s
+++ b/gold/testsuite/nanomips_eh_frame_start_end_syms.s
@@ -1,0 +1,25 @@
+
+    .section .text, "ax", @progbits
+    # Dummy function to generate eh frame
+    .cfi_startproc
+    .ent _start
+_start:
+    addiu $a1, $a2, 1
+
+    .end _start
+    .cfi_endproc
+    .size _start, .-_start
+
+    .extern __eh_frame_start
+    .extern __eh_frame_end
+    # If not referenced, eh frame start/end symbols are not added
+    .section .reference_start_end, "aw", @progbits
+    .4byte __eh_frame_start
+    .4byte __eh_frame_end
+
+    .ifdef hdr
+    .4byte __eh_frame_hdr_start
+    .4byte __eh_frame_hdr_end
+    .endif
+
+

--- a/gold/testsuite/nanomips_eh_frame_start_end_syms.sh
+++ b/gold/testsuite/nanomips_eh_frame_start_end_syms.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+# nanomips_eh_frame_start_end_syms.sh -- test generation of start/end eh_frame
+# section symbols.
+
+# Copyright (C) 2024 Free Software Foundation, Inc.
+# Written by Andrija Jovanovic <andrija.jovanovic@htecgroup.com>.
+
+# This file is part of gold.
+
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston,
+# MA 02110-1301, USA.
+
+check()
+{
+    file=$1
+    pattern=$2
+
+    found=`grep "$pattern" $file`
+    if test -z "$found"; then
+	echo "pattern \"$pattern\" not found in file $file."
+	exit 1
+    fi
+}
+
+
+check nanomips_eh_frame_start_end_syms_1.stdout ".eh_frame         PROGBITS        00001000 001000 000028"
+# Global hidden symbols may be demoted to local symbols, that's why that is
+# not checked
+check nanomips_eh_frame_start_end_syms_1.stdout "00001000     0 NOTYPE [A-Z ]* HIDDEN [0-9 ]* __eh_frame_start"
+check nanomips_eh_frame_start_end_syms_1.stdout "00001028     0 NOTYPE [A-Z ]* HIDDEN [0-9 ]* __eh_frame_end"
+
+check nanomips_eh_frame_start_end_syms_2.stdout ".eh_frame         PROGBITS        00001000 001000 000028"
+check nanomips_eh_frame_start_end_syms_2.stdout ".eh_frame_hdr     PROGBITS        00002000 002000 000014"
+check nanomips_eh_frame_start_end_syms_2.stdout "00001000     0 NOTYPE [A-Z ]* HIDDEN [0-9 ]* __eh_frame_start"
+check nanomips_eh_frame_start_end_syms_2.stdout "00001028     0 NOTYPE [A-Z ]* HIDDEN [0-9 ]* __eh_frame_end"
+check nanomips_eh_frame_start_end_syms_2.stdout "00002000     0 NOTYPE [A-Z ]* HIDDEN [0-9 ]* __eh_frame_hdr_start"
+check nanomips_eh_frame_start_end_syms_2.stdout "00002014     0 NOTYPE [A-Z ]* HIDDEN [0-9 ]* __eh_frame_hdr_end"


### PR DESCRIPTION
  eh_frame start and end symbols need to be defined if there is an
  eh_frame section. These symbols are needed by libunwind when used
  without libgcc.